### PR TITLE
Add a new option: `readyRegex`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,22 @@ Works in synchronous or asynchronous mode.
     }, 
 ```
 
+#### Waiting for an async process to be ready:
+
+Wait for a background process to signal that it's ready before continuing on to the next task by providing `readyRegex`.
+
+```
+    proxy: {
+        command: 'browsermob-proxy',
+        options: {
+            async: true,
+            readyRegex: /Started SelectChannelConnector/
+        }
+    },
+```
+
+This is useful for making sure a proxy is ready to receive requests before beginning tests.
+
 #### Killing an async process
 
 Stop a running async task with the `:kill` task argument. 

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -18,10 +18,11 @@ module.exports = function( grunt ) {
         var cp = require('child_process');
         var proc;
 
-        var options = this.options({stdout: true, stderr: true, failOnError: true, canKill: true, stopIfStarted: false});
+        var options = this.options({stdout: true, stderr: true, failOnError: true, canKill: true, stopIfStarted: false, readyRegex: undefined});
 
         var data = this.data;
-        var done = options.async ? function() {} : this.async();
+        var shouldWaitUntilReady = !!options.readyRegex;
+        var done = options.async && !shouldWaitUntilReady ? function() {} : this.async();
         var target = this.target;
         var file, args, opts;
         var cmd = data.command;
@@ -117,6 +118,10 @@ module.exports = function( grunt ) {
                     options.stdout(data);
                 } else if(options.stdout === true || grunt.option('verbose')) {
                     log.write(data);
+                }
+
+                if (shouldWaitUntilReady && options.readyRegex.test(data)) {
+                    done();
                 }
             });
         }


### PR DESCRIPTION
This will wait for a background process to be ready before continuing on to the next task. It's useful for waiting for a proxy to be ready to receive requests before beginning tests.

@mgs255 Do you have any feedback, or does this look good to go?